### PR TITLE
fix multi-host issue

### DIFF
--- a/docker/docker_build_common.sh
+++ b/docker/docker_build_common.sh
@@ -17,7 +17,7 @@
 declare -r USER=astraea
 declare -r BUILD=${BUILD:-false}
 declare -r RUN=${RUN:-true}
-declare -r ADDRESS=$([[ "$(which ipconfig)" != "" ]] && ipconfig getifaddr en0 || hostname -i)
+declare -r ADDRESS=$([[ "$(which ipconfig)" != "" ]] && ipconfig getifaddr en0 || hostname -i | awk '{print $1}')
 
 # ===================================[functions]===================================
 


### PR DESCRIPTION
如果有多張網卡會顯示下列訊息,我們只需要保留一個address就好了
```
node.id=11539
broker address: 192.168.31.57 192.168.31.94 172.17.0.1 172.18.0.1 fe80::da5e:d3ff:fe2a:2a9b fe80::6a54:5aff:fecb:4729 fe80::42:ffff:fe04:9b86:10883
jmx address: 192.168.31.57 192.168.31.94 172.17.0.1 172.18.0.1 fe80::da5e:d3ff:fe2a:2a9b fe80::6a54:5aff:fecb:4729 fe80::42:ffff:fe04:9b86:12836
exporter address: 192.168.31.57 192.168.31.94 172.17.0.1 172.18.0.1 fe80::da5e:d3ff:fe2a:2a9b fe80::6a54:5aff:fecb:4729 fe80::42:ffff:fe04:9b86:11841
```